### PR TITLE
Configure automatic GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# dut4-fls
+# DUT4 FLS
+
+This repository hosts the DUT4 Riser Hotzone Overlay Tester.
+
+To view the site once published, visit [https://theboysday.github.io/dut4-fls/](https://theboysday.github.io/dut4-fls/).
+
+## GitHub Pages deployment
+
+A GitHub Actions workflow is included to automatically deploy the contents of the `main` branch to GitHub Pages.
+Once this workflow runs on your main branch, the site will be available at the URL above.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish `main` to Pages
- document project and deployment steps
- disable Jekyll processing for static assets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c00c38aa38832289073b4e34b898d2